### PR TITLE
fix (typo) : Fixed typo "tricoter" instead of "tricotter" in TP/TP_1_Rmarkdown.Rmd

### DIFF
--- a/TP/TP_01_Rmarkdown.Rmd
+++ b/TP/TP_01_Rmarkdown.Rmd
@@ -60,7 +60,7 @@ Une fois le document créé, `RStudio` propose un contenu "didactique" par défa
 
 Vous pouvez compiler ce document en cliquant sur la commande 
 `Knit` en haut à gauche, à côté d'une pelotte de laine
-(en anglais, "to knit" signifie "tricotter").
+(en anglais, "to knit" signifie "tricoter").
 
 Si tous fonctionne bien, `RStudio` va générer un document `HTML`, qu'il ouvre
 dans une nouvelle fenêtre.


### PR DESCRIPTION
Fix tricoter "instead" of "tricotter"