### PR TITLE
fix: Use a common hack to render LaTeX with any Markdown render engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ et sa [librairie](https://CRAN.R-project.org/package=fivethirtyeight) associée
 ## Points bonus
 
 * Typos et erreurs dans les diapos et fiches
-  * k-ème PR accepté = $\frac{1}{2^{k}}$ points en plus sur la note du CC.
+  * k-ème PR accepté = <img src="https://render.githubusercontent.com/render/math?math=\frac{1}{2^{k}}"> points en plus sur la note du CC.
   
 ## Attribution
 


### PR DESCRIPTION
Here is an example of what this track do:

![Capture d’écran de 2022-03-08 14-36-06](https://user-images.githubusercontent.com/20240488/157248711-7e997960-c380-44c1-ac97-c4601979581d.png)

...instead of:

![Capture d’écran de 2022-03-08 14-38-14](https://user-images.githubusercontent.com/20240488/157248952-e1dfac7d-43cc-42b3-a66f-b39dd0e14243.png)
