### PR TITLE
fix typo : missing 's' in 'jeu de donnée' (Cours_02_quali)

### DIFF
--- a/slide/Cours_02_quali.Rmd
+++ b/slide/Cours_02_quali.Rmd
@@ -182,7 +182,7 @@ head(penguins)
 dim(penguins)
 ```
 
-Le jeu de donnée comporte `r nrow(penguins)` lignes,
+Le jeu de données comporte `r nrow(penguins)` lignes,
 chacune correspondant à une espèce.
 
 ```{r penguin-3}


### PR DESCRIPTION
Fix typo in Cours_02_quali : 'jeu de donnée'  -> 'jeu de données' 