### PR TITLE
Fix LaTeX render

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ et sa [librairie](https://CRAN.R-project.org/package=fivethirtyeight) associée
 ## Points bonus
 
 * Typos et erreurs dans les diapos et fiches
-  * k-ème PR accepté = $\frac{1}{2^{k}}$ points en plus sur la note du CC.
+  * k-ème PR accepté = ![formule](https://latex.codecogs.com/png.image?\inline&space;\large&space;\dpi{110}\bg{white}\frac{1}{2^{k}}) points en plus sur la note du CC.
   
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ et sa [librairie](https://CRAN.R-project.org/package=fivethirtyeight) associée
 ## Points bonus
 
 * Typos et erreurs dans les diapos et fiches
-  * k-ème PR accepté = ![formule](https://latex.codecogs.com/png.image?\inline&space;\large&space;\dpi{110}\bg{white}\frac{1}{2^{k}}) points en plus sur la note du CC.
+  * k-ème PR accepté ![=1/2^k](https://render.githubusercontent.com/render/math?math={=1/2^k}#gh-light-mode-only) ![=1/2^k](https://render.githubusercontent.com/render/math?math={\color{white}=1/2^k}#gh-dark-mode-only) points en plus sur la note du CC.
   
 ## Attribution
 


### PR DESCRIPTION
Fix issue #27 

With this fix, the *LaTeX* inside the Readme for GitHub dark mode is correctly shown.