### PR TITLE
Remove README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ L'adaptation et la traduction qui en a été faite ici est assez lâche,
 et ce dernier ne saurait être tenu responsable de toutes les erreurs qui
 pourraient s'être glissées dans ces pages.
 
-## License
+## Licence
 
 Texte et figures sous [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
 


### PR DESCRIPTION
Change 'License' en 'Licence' dans le README.md pour être correspondre à la traduction française